### PR TITLE
DefaultRegisteredServiceResourceNamingStrategy already has dot, remov…

### DIFF
--- a/support/cas-mgmt-support-version-control/src/main/java/org/apereo/cas/mgmt/VersionControlServicesManager.java
+++ b/support/cas-mgmt-support-version-control/src/main/java/org/apereo/cas/mgmt/VersionControlServicesManager.java
@@ -92,8 +92,8 @@ public class VersionControlServicesManager extends ManagementServicesManager {
     public void checkForRename(final RegisteredService service) {
         val existing = findServiceBy(service.getId());
         if (existing != null) {
-            val oldName = getNamingStrategy().build(existing, ".json");
-            val newName = getNamingStrategy().build(service, ".json");
+            val oldName = getNamingStrategy().build(existing, "json");
+            val newName = getNamingStrategy().build(service, "json");
             if (!oldName.equals(newName)) {
                 try (git) {
                     git.move(oldName, newName);


### PR DESCRIPTION
error occur when name1-xxx..json move to name2-xxx..json
DefaultRegisteredServiceResourceNamingStrategy already has dot,('.'), remove it from args
